### PR TITLE
use generic type to make code cleaner

### DIFF
--- a/x-pack/plugins/observability/public/pages/rule_details/components/page_title.tsx
+++ b/x-pack/plugins/observability/public/pages/rule_details/components/page_title.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useState } from 'react';
+import React from 'react';
 import moment from 'moment';
 import { EuiText, EuiFlexGroup, EuiFlexItem, EuiBadge, EuiSpacer } from '@elastic/eui';
 import { PageHeaderProps } from '../types';
@@ -14,12 +14,7 @@ import { getHealthColor } from '../../rules/config';
 
 export function PageTitle({ rule }: PageHeaderProps) {
   const { triggersActionsUi } = useKibana().services;
-  const [isTagsPopoverOpen, setIsTagsPopoverOpen] = useState<boolean>(false);
-  const tagsClicked = () =>
-    setIsTagsPopoverOpen(
-      (oldStateIsTagsPopoverOpen) => rule.tags.length > 0 && !oldStateIsTagsPopoverOpen
-    );
-  const closeTagsPopover = () => setIsTagsPopoverOpen(false);
+
   return (
     <>
       <EuiFlexGroup alignItems="center">
@@ -49,12 +44,9 @@ export function PageTitle({ rule }: PageHeaderProps) {
         <EuiSpacer size="xs" />
       </EuiFlexGroup>
       {rule.tags.length > 0 &&
-        triggersActionsUi.getRuleTagBadge({
-          spread: true,
-          isOpen: isTagsPopoverOpen,
+        triggersActionsUi.getRuleTagBadge<'all'>({
+          showAllTags: true,
           tags: rule.tags,
-          onClick: () => tagsClicked(),
-          onClose: () => closeTagsPopover(),
         })}
       <EuiSpacer size="xs" />
     </>

--- a/x-pack/plugins/observability/public/pages/rules/index.tsx
+++ b/x-pack/plugins/observability/public/pages/rules/index.tsx
@@ -199,7 +199,7 @@ function RulesPage() {
         'data-test-subj': 'rulesTableCell-tagsPopover',
         render: (ruleTags: string[], item: RuleTableItem) => {
           return ruleTags.length > 0
-            ? triggersActionsUi.getRuleTagBadge({
+            ? triggersActionsUi.getRuleTagBadge<'default'>({
                 isOpen: tagPopoverOpenIndex === item.index,
                 tags: ruleTags,
                 onClick: () => setTagPopoverOpenIndex(item.index),

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/index.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/index.tsx
@@ -38,9 +38,6 @@ export const RuleTagFilter = suspendedComponentWithProps(
 export const RuleStatusFilter = suspendedComponentWithProps(
   lazy(() => import('./rules_list/components/rule_status_filter'))
 );
-export const RuleTagBadge = suspendedComponentWithProps(
-  lazy(() => import('./rules_list/components/rule_tag_badge'))
-);
 export const RuleEventLogList = suspendedComponentWithProps(
   lazy(() => import('./rule_details/components/rule_event_log_list'))
 );

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_tag_badge.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_tag_badge.test.tsx
@@ -58,7 +58,7 @@ describe('RuleTagBadge', () => {
   });
 
   it('shows all the tags without clicking when passing "spread" props with "true"', () => {
-    const wrapper = mountWithIntl(<RuleTagBadge tags={tags} spread={true} />);
+    const wrapper = mountWithIntl(<RuleTagBadge tags={tags} showAllTags={true} />);
     expect(wrapper.find('[data-test-subj="spreadTags"]').exists()).toBeTruthy();
     expect(wrapper.find('[data-test-subj="ruleTagBadgeItem-a"]').exists()).toBeTruthy();
     expect(wrapper.find('[data-test-subj="ruleTagBadgeItem-b"]').exists()).toBeTruthy();

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_tag_badge.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_tag_badge.tsx
@@ -16,55 +16,61 @@ const tagTitle = i18n.translate(
   }
 );
 
+export type RuleTagBadgeOptions = 'all' | 'default';
+
+interface RuleTagBadgeBasicOptions {
+  isOpen: boolean;
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+  onClose: () => void;
+}
+
 export interface RuleTagBadgeCommonProps {
+  showAllTags?: boolean;
   tags: string[];
   badgeDataTestSubj?: string;
   titleDataTestSubj?: string;
   tagItemDataTestSubj?: (tag: string) => string;
 }
-export type RuleTagBadgeConditionalProps =
-  | {
-      isOpen: boolean;
-      onClick: React.MouseEventHandler<HTMLButtonElement>;
-      onClose: () => void;
-    }
-  | {
-      spread: boolean;
-    };
-export type RuleTagBadgeProps = RuleTagBadgeCommonProps & RuleTagBadgeConditionalProps;
+
+export type RuleTagBadgeProps<T extends RuleTagBadgeOptions = 'default'> = T extends 'default'
+  ? RuleTagBadgeBasicOptions & RuleTagBadgeCommonProps
+  : T extends 'all'
+  ? RuleTagBadgeCommonProps
+  : never;
+
 const containerStyle = {
   width: '300px',
 };
 
 const getTagItemDataTestSubj = (tag: string) => `ruleTagBadgeItem-${tag}`;
 
-export const RuleTagBadge = (props: RuleTagBadgeProps) => {
+export const RuleTagBadge = <T extends RuleTagBadgeOptions>(props: RuleTagBadgeProps<T>) => {
   const {
+    showAllTags = false,
     tags = [],
     badgeDataTestSubj = 'ruleTagBadge',
     titleDataTestSubj = 'ruleTagPopoverTitle',
     tagItemDataTestSubj = getTagItemDataTestSubj,
   } = props;
+  const { isOpen, onClose, onClick } = props as RuleTagBadgeBasicOptions;
 
   const badge = useMemo(() => {
-    if ('onClick' in props) {
-      return (
-        <EuiBadge
-          data-test-subj={badgeDataTestSubj}
-          color="hollow"
-          iconType="tag"
-          iconSide="left"
-          tabIndex={-1}
-          onClick={props.onClick}
-          onClickAriaLabel="Tags"
-          iconOnClick={props.onClick}
-          iconOnClickAriaLabel="Tags"
-        >
-          {tags.length}
-        </EuiBadge>
-      );
-    }
-  }, [tags, badgeDataTestSubj, props]);
+    return (
+      <EuiBadge
+        data-test-subj={badgeDataTestSubj}
+        color="hollow"
+        iconType="tag"
+        iconSide="left"
+        tabIndex={-1}
+        onClick={onClick}
+        onClickAriaLabel="Tags"
+        iconOnClick={onClick}
+        iconOnClickAriaLabel="Tags"
+      >
+        {tags.length}
+      </EuiBadge>
+    );
+  }, [badgeDataTestSubj, onClick, tags.length]);
 
   const tagBadges = useMemo(
     () =>
@@ -81,7 +87,7 @@ export const RuleTagBadge = (props: RuleTagBadgeProps) => {
       )),
     [tags, tagItemDataTestSubj]
   );
-  if ('spread' in props) {
+  if (showAllTags) {
     return (
       // Put 0 to fix negative left margin value.
       <EuiFlexGroup data-test-subj="spreadTags" style={{ marginLeft: 0 }} wrap={true}>
@@ -94,8 +100,8 @@ export const RuleTagBadge = (props: RuleTagBadgeProps) => {
     <EuiPopover
       button={badge}
       anchorPosition="upCenter"
-      isOpen={props.isOpen!} // The props exists as it's required in props types
-      closePopover={props.onClose!}
+      isOpen={isOpen} // The props exists as it's required in props types
+      closePopover={onClose}
     >
       <EuiPopoverTitle data-test-subj={titleDataTestSubj}>{tagTitle}</EuiPopoverTitle>
       <div style={containerStyle}>{tagBadges}</div>

--- a/x-pack/plugins/triggers_actions_ui/public/common/get_rule_tag_badge.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/common/get_rule_tag_badge.tsx
@@ -5,10 +5,17 @@
  * 2.0.
  */
 
-import React from 'react';
-import { RuleTagBadge } from '../application/sections';
-import type { RuleTagBadgeProps } from '../application/sections/rules_list/components/rule_tag_badge';
+import { lazy, ReactElement } from 'react';
+import { suspendedComponentWithProps } from '../application/lib/suspended_component_with_props';
+import type {
+  RuleTagBadgeProps,
+  RuleTagBadgeOptions,
+} from '../application/sections/rules_list/components/rule_tag_badge';
 
-export const getRuleTagBadgeLazy = (props: RuleTagBadgeProps) => {
-  return <RuleTagBadge {...props} />;
+export const getRuleTagBadgeLazy = <T extends RuleTagBadgeOptions = 'default'>(
+  props: RuleTagBadgeProps<T>
+) => {
+  return suspendedComponentWithProps<RuleTagBadgeProps<T>>(
+    lazy(() => import('../application/sections/rules_list/components/rule_tag_badge'))
+  ) as unknown as ReactElement<RuleTagBadgeProps<T>>;
 };

--- a/x-pack/plugins/triggers_actions_ui/public/mocks.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/mocks.ts
@@ -23,6 +23,8 @@ import {
   ConnectorEditFlyoutProps,
   AlertsTableProps,
   AlertsTableConfigurationRegistry,
+  RuleTagBadgeOptions,
+  RuleTagBadgeProps,
 } from './types';
 import { getAlertsTableLazy } from './common/get_alerts_table';
 import { getRuleStatusDropdownLazy } from './common/get_rule_status_dropdown';
@@ -81,8 +83,8 @@ function createStartMock(): TriggersAndActionsUIPublicPluginStart {
     getRuleStatusFilter: (props) => {
       return getRuleStatusFilterLazy(props);
     },
-    getRuleTagBadge: (props) => {
-      return getRuleTagBadgeLazy(props);
+    getRuleTagBadge: <T extends RuleTagBadgeOptions>(props: RuleTagBadgeProps<T>) => {
+      return getRuleTagBadgeLazy<T>(props);
     },
     getRuleEventLogList: (props) => {
       return getRuleEventLogListLazy(props);

--- a/x-pack/plugins/triggers_actions_ui/public/plugin.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/plugin.ts
@@ -55,6 +55,7 @@ import type {
   RuleTagFilterProps,
   RuleStatusFilterProps,
   RuleTagBadgeProps,
+  RuleTagBadgeOptions,
   RuleEventLogListProps,
   RulesListNotifyBadgeProps,
   AlertsTableConfigurationRegistry,
@@ -92,7 +93,9 @@ export interface TriggersAndActionsUIPublicPluginStart {
   getRuleStatusDropdown: (props: RuleStatusDropdownProps) => ReactElement<RuleStatusDropdownProps>;
   getRuleTagFilter: (props: RuleTagFilterProps) => ReactElement<RuleTagFilterProps>;
   getRuleStatusFilter: (props: RuleStatusFilterProps) => ReactElement<RuleStatusFilterProps>;
-  getRuleTagBadge: (props: RuleTagBadgeProps) => ReactElement<RuleTagBadgeProps>;
+  getRuleTagBadge: <T extends RuleTagBadgeOptions>(
+    props: RuleTagBadgeProps<T>
+  ) => ReactElement<RuleTagBadgeProps<T>>;
   getRuleEventLogList: (props: RuleEventLogListProps) => ReactElement<RuleEventLogListProps>;
   getRulesListNotifyBadge: (
     props: RulesListNotifyBadgeProps
@@ -280,7 +283,7 @@ export class Plugin
       getRuleStatusFilter: (props: RuleStatusFilterProps) => {
         return getRuleStatusFilterLazy(props);
       },
-      getRuleTagBadge: (props: RuleTagBadgeProps) => {
+      getRuleTagBadge: <T extends RuleTagBadgeOptions>(props: RuleTagBadgeProps<T>) => {
         return getRuleTagBadgeLazy(props);
       },
       getRuleEventLogList: (props: RuleEventLogListProps) => {

--- a/x-pack/plugins/triggers_actions_ui/public/types.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/types.ts
@@ -48,7 +48,10 @@ import { TypeRegistry } from './application/type_registry';
 import type { ComponentOpts as RuleStatusDropdownProps } from './application/sections/rules_list/components/rule_status_dropdown';
 import type { RuleTagFilterProps } from './application/sections/rules_list/components/rule_tag_filter';
 import type { RuleStatusFilterProps } from './application/sections/rules_list/components/rule_status_filter';
-import type { RuleTagBadgeProps } from './application/sections/rules_list/components/rule_tag_badge';
+import type {
+  RuleTagBadgeProps,
+  RuleTagBadgeOptions,
+} from './application/sections/rules_list/components/rule_tag_badge';
 import type { RuleEventLogListProps } from './application/sections/rule_details/components/rule_event_log_list';
 import type { RulesListNotifyBadgeProps } from './application/sections/rules_list/components/rules_list_notify_badge';
 
@@ -86,6 +89,7 @@ export type {
   RuleTagFilterProps,
   RuleStatusFilterProps,
   RuleTagBadgeProps,
+  RuleTagBadgeOptions,
   RuleEventLogListProps,
   RulesListNotifyBadgeProps,
 };


### PR DESCRIPTION
When I was reviewing you PR, I wanted to make sure that not all props where required to make the component work. So I came up with this solution.

Let me know, if you like it too